### PR TITLE
lmkd: Fix lowmem_minfree out of bounds

### DIFF
--- a/lmkd.cpp
+++ b/lmkd.cpp
@@ -2824,7 +2824,7 @@ static void mp_event_common(int data, uint32_t events, struct polling_params *po
         }
 
         if (min_score_adj == OOM_SCORE_ADJ_MAX + 1) {
-            if (debug_process_killing) {
+            if (debug_process_killing && lowmem_targets_size) {
                 ALOGI("Ignore %s memory pressure event "
                       "(free memory=%ldkB, cache=%ldkB, limit=%ldkB)",
                       level_name[level], other_free * page_k, other_file * page_k,


### PR DESCRIPTION
lmkd daemon launches before system_server. If lowmem_targets_size
does not initialize by system_server, the value will be zero.
Before system_server starts lmkd receives a psi event
and debug_process_killing on, the lmkd crashes here.

Bug: 209090314
Signed-off-by: liuhailong <liuhailong@oppo.com>
Change-Id: I0736a882ed1ff5eee2b07676ae590a2cb2a7721c