### PR TITLE
lmkd: Fix a comparison operation with uninitialized variable.

### DIFF
--- a/lmkd.cpp
+++ b/lmkd.cpp
@@ -3284,7 +3284,8 @@ static void call_handler(struct event_handler_info* handler_info,
         resume_polling(poll_params, curr_tm);
         break;
     case POLLING_DO_NOT_CHANGE:
-        if (get_time_diff_ms(&poll_params->poll_start_tm, &curr_tm) > PSI_WINDOW_SIZE_MS) {
+        if (poll_params->poll_handler &&
+            get_time_diff_ms(&poll_params->poll_start_tm, &curr_tm) > PSI_WINDOW_SIZE_MS) {
             /* Polled for the duration of PSI window, time to stop */
             poll_params->poll_handler = NULL;
         }


### PR DESCRIPTION
Prevent comparing uninitialized poll_start_tm with curr_tm in call_handler().
The bug caused by this has been fixed by the commit: d816ab.
But the main bug is not fixed yet and it may cause problem
in later if we add another operations in this if block.

Change-Id: Id13318297a2cbf2f9784134a2ccd648cc221e8c4
Signed-off-by: Yoonjae Jeon <yj213.jeon@samsung.com>